### PR TITLE
Fix for return of None from the API

### DIFF
--- a/lakeside/__init__.py
+++ b/lakeside/__init__.py
@@ -40,7 +40,8 @@ def get_devices(username, password):
     info = r.json()
 
     for item in info['items']:
-        devices.append({'address': item['device']['wifi']['lan_ip_addr'], 'code': item['device']['local_code'], 'type': item['device']['product']['product_code'], 'name': item['device']['alias_name']})
+        if item['device'] is not None:
+            devices.append({'address': item['device']['wifi']['lan_ip_addr'], 'code': item['device']['local_code'], 'type': item['device']['product']['product_code'], 'name': item['device']['alias_name']})
 
     return devices
 


### PR DESCRIPTION
The Eufy API can sometimes return None as an info['items']['device'].
Make sure it doesn't try to access items on any of those None objects.