### PR TITLE
Switch from pycryptodome to pythonaes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     ],
     install_requires=[
         "protobuf",
-        "pycryptodome",
+        "pythonaes",
         "requests",
     ]
 )


### PR DESCRIPTION
pythonaes is a pure Python AES implementation. While slower, it has
the advantage of not requiring a toolchain and a hefty multi-purpose
library for a single algorithm. The packets the library is operating
on are quite small, so performance shouldn't be a huge issue.